### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "EthereumClassicExplorer",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A lightweight ethereum classic block explorer",
   "repository": "https://github.com/ethereumproject/explorer",
   "license": "MIT",
   "dependencies": {
-    "bignumber.js": "^2.4.0",
-    "body-parser": "^1.15.2",
-    "ejs": "~0.8.5",
-    "express": "^4.14.0",
-    "mongoose": "^4.5.8",
-    "morgan": "^1.7.0",
-    "serve-favicon": "~2.1.3",
-    "socket.io": "^1.4.8",
+    "bignumber.js": "^5.0.0",
+    "body-parser": "^1.12.2",
+    "ejs": "~2.5.7",
+    "express": "^4.16.0",
+    "mongoose": "^4.13.8",
+    "morgan": "^1.9.0",
+    "serve-favicon": "~2.4.5",
+    "socket.io": "^2.0.4",
     "solc": "file:local_modules/solc",
     "web3": "git://github.com/elaineo/web3.js#develop"
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/13103499/34694382-854485b4-f48c-11e7-943a-b4cc96727f46.png)


update versioning on dependencies
# ejs has security warning below 2.5.5

update version..... should prob do this more often....