### PR TITLE
support block hash query

### DIFF
--- a/public/js/controllers/TxController.js
+++ b/public/js/controllers/TxController.js
@@ -14,6 +14,15 @@ angular.module('BlocksApp').controller('TxController', function($stateParams, $r
       url: '/web3relay',
       data: {"tx": $scope.hash}
     }).success(function(data) {
+      if (data.error) {
+        if (data.isBlock) {
+          // this is a blockHash
+          $location.path("/block/" + $scope.hash);
+          return;
+        }
+        $location.path("/err404/tx/" + $scope.hash);
+        return;
+      }
       $scope.tx = data;
       if (data.timestamp)
         $scope.tx.datetime = new Date(data.timestamp*1000); 

--- a/routes/web3relay.js
+++ b/routes/web3relay.js
@@ -39,8 +39,21 @@ exports.data = function(req, res){
     web3.eth.getTransaction(txHash, function(err, tx) {
       if(err || !tx) {
         console.error("TxWeb3 error :" + err)
-        res.write(JSON.stringify({"error": true}));
-        res.end();
+        if (!tx) {
+          web3.eth.getBlock(txHash, function(err, block) {
+            if(err || !block) {
+              console.error("BlockWeb3 error :" + err)
+              res.write(JSON.stringify({"error": true}));
+            } else {
+              console.log("BlockWeb3 found: " + txHash)
+              res.write(JSON.stringify({"error": true, "isBlock": true}));
+            }
+            res.end();
+          });
+        } else {
+          res.write(JSON.stringify({"error": true}));
+          res.end();
+        }
       } else {
         var ttx = tx;
         ttx.value = etherUnits.toEther( new BigNumber(tx.value), "wei");

--- a/routes/web3relay.js
+++ b/routes/web3relay.js
@@ -124,9 +124,14 @@ exports.data = function(req, res){
 
 
   } else if ("block" in req.body) {
-    var blockNum = parseInt(req.body.block);
+    var blockNumOrHash;
+    if (/^(0x)?[0-9a-f]{64}$/i.test(req.body.block.trim())) {
+        blockNumOrHash = req.body.block.toLowerCase();
+    } else {
+        blockNumOrHash = parseInt(req.body.block);
+    }
 
-    web3.eth.getBlock(blockNum, function(err, block) {
+    web3.eth.getBlock(blockNumOrHash, function(err, block) {
       if(err || !block) {
         console.error("BlockWeb3 error :" + err)
         res.write(JSON.stringify({"error": true}));


### PR DESCRIPTION
support both direct link (e.g. /block/hash) and search query.

etherscan.io already support /block/hash direct link like as following
https://etherscan.io/block/0x6ffdd1137835ccf41a28e753e64b99afd780ab53a3b791e433f20feb24214007

but etherscan.io does not support search query.
