### PR TITLE
configurable settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,19 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var bodyParser = require('body-parser');
 
+var config = {};
+try {
+  config = require('./config.json');
+} catch(e) {
+  if (e.code == 'MODULE_NOT_FOUND') {
+    console.log('No config file found. Using default configuration... (tools/config.json)');
+    config = require('./tools/config.json');
+  } else {
+    throw e;
+    process.exit(1);
+  }
+}
+
 var app = express();
 app.set('port', process.env.PORT || 3000);
 
@@ -28,14 +41,18 @@ global.__lib = __dirname + '/lib/';
 // client
 
 app.get('/', function(req, res) {
-  res.render('index');
+  res.render('index', config);
+});
+
+app.get('/config', function(req, res) {
+  res.json(config.settings);
 });
 
 require('./routes')(app);
 
 // let angular catch them
 app.use(function(req, res) {
-  res.render('index');
+  res.render('index', config);
 });
 
 // error handlers

--- a/public/js/controllers/AddressController.js
+++ b/public/js/controllers/AddressController.js
@@ -10,6 +10,7 @@ angular.module('BlocksApp').controller('AddressController', function($stateParam
     $rootScope.$state.current.data["pageSubTitle"] = $stateParams.hash;
     $scope.addrHash = $stateParams.hash;
     $scope.addr = {"balance": 0, "count": 0};
+    $scope.settings = $rootScope.setup;
 
     //fetch web3 stuff
     $http({

--- a/public/js/controllers/BlockController.js
+++ b/public/js/controllers/BlockController.js
@@ -7,6 +7,7 @@ angular.module('BlocksApp').controller('BlockController', function($stateParams,
 
     $rootScope.$state.current.data["pageSubTitle"] = $stateParams.number;
     $scope.blockNum = $stateParams.number;
+    $scope.settings = $rootScope.setup;
 
     //fetch transactions
     $http({

--- a/public/js/controllers/ContractController.js
+++ b/public/js/controllers/ContractController.js
@@ -32,6 +32,7 @@ angular.module('BlocksApp').controller('ContractController', function($statePara
     $scope.form = {};
     $scope.contract = {"address": $stateParams.addr} 
     $scope.errors = {};
+    $scope.settings = $rootScope.setup;
     
     $scope.submitCode = function() {
       console.log($scope.contract)

--- a/public/js/controllers/DAOController.js
+++ b/public/js/controllers/DAOController.js
@@ -7,6 +7,7 @@ angular.module('BlocksApp').controller('DAOController', function($stateParams, $
     if (activeTab.length > 1)
       $scope.activeTab = activeTab[1];
 
+    $scope.settings = $rootScope.setup;
     $scope.dao = {"balance": 0, "extra_balance": 0};
 
     //fetch dao stuff

--- a/public/js/controllers/ErrController.js
+++ b/public/js/controllers/ErrController.js
@@ -2,5 +2,6 @@ angular.module('BlocksApp').controller('ErrController', function($stateParams, $
 
     $rootScope.$state.current.data["pageSubTitle"] = $stateParams.hash;
     $scope.thing = $stateParams.thing;
+    $scope.settings = $rootScope.setup;
 
 })

--- a/public/js/controllers/HomeController.js
+++ b/public/js/controllers/HomeController.js
@@ -37,6 +37,7 @@ angular.module('BlocksApp').controller('HomeController', function($rootScope, $s
     $scope.reloadTransactions();
     $scope.txLoading = false;
     $scope.blockLoading = false;
+    $scope.settings = $rootScope.setup;
 })
 .directive('summaryStats', function($http) {
   return {

--- a/public/js/controllers/StatsController.js
+++ b/public/js/controllers/StatsController.js
@@ -1,6 +1,7 @@
 angular.module('BlocksApp').controller('StatsController', function($stateParams, $rootScope, $scope) {
 
     $rootScope.isHome = false;
+    $scope.settings = $rootScope.setup;
   
     /*
       Chart types: 

--- a/public/js/controllers/TokenController.js
+++ b/public/js/controllers/TokenController.js
@@ -11,6 +11,7 @@ angular.module('BlocksApp').controller('TokenController', function($stateParams,
     $scope.addrHash = isAddress($stateParams.hash) ? $stateParams.hash : undefined;
     var address = $scope.addrHash;
     $scope.token = {"balance": 0};
+    $scope.settings = $rootScope.setup;
 
     //fetch dao stuff
     $http({

--- a/public/js/controllers/TokenListController.js
+++ b/public/js/controllers/TokenListController.js
@@ -3,6 +3,7 @@ angular.module('BlocksApp').controller('TokenListController', function($statePar
         // initialize core components
         App.initAjax();
     });
+    $scope.settings = $rootScope.setup;
 
     $http.get('/tokens.json')
       .then(function(res){

--- a/public/js/controllers/TxController.js
+++ b/public/js/controllers/TxController.js
@@ -7,6 +7,7 @@ angular.module('BlocksApp').controller('TxController', function($stateParams, $r
     $rootScope.$state.current.data["pageSubTitle"] = $stateParams.hash;
     $scope.hash = $stateParams.hash;
     $scope.tx = {"hash": $scope.hash};
+    $scope.settings = $rootScope.setup;
 
     //fetch web3 stuff
     $http({

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -35,6 +35,13 @@ BlocksApp.factory('settings', ['$rootScope', '$http', function($rootScope, $http
     return settings;
 }]);
 
+/* Load config settings */
+BlocksApp.factory('setupObj', ['$rootScope', '$http', function($rootScope, $http) {
+    return $http.get('/config').then(function(res) {
+        return res.data;
+    })
+}]);
+
 /* Setup App Main Controller */
 BlocksApp.controller('MainController', ['$scope', '$rootScope', function($scope, $rootScope) {
     $scope.$on('$viewContentLoaded', function() {
@@ -316,7 +323,10 @@ BlocksApp.filter('timeDuration', function() {
 })
 
 /* Init global settings and run the app */
-BlocksApp.run(["$rootScope", "settings", "$state", function($rootScope, settings, $state) {
+BlocksApp.run(["$rootScope", "settings", "$state", "setupObj", function($rootScope, settings, $state, setupObj) {
     $rootScope.$state = $state; // state to be accessed from view
     $rootScope.$settings = settings; // state to be accessed from view
+    setupObj.then(function(res) {
+        $rootScope.setup = res;
+    });
 }]);

--- a/public/views/address.html
+++ b/public/views/address.html
@@ -11,7 +11,7 @@
                 <span class="eth-stat-title">
                   {{ addr.balance | number: 10 }} </span><br>
                 <span class="eth-stat-text">
-                  ETC Balance <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Note: Balance may not reflect transaction data if you have transactions resulting from Contract Internal Transactions. We are working on adding that functionality."></i>
+                  {{ settings.symbol }} Balance <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="Note: Balance may not reflect transaction data if you have transactions resulting from Contract Internal Transactions. We are working on adding that functionality."></i>
                   </span><br> 
                   <div class="margin-top-20">
                   <span class="fade">{{ addr.ethfiat | number: 10 }}</span> <span class="eth-stat-text fade">ETH-F balance
@@ -69,7 +69,7 @@
                           <th width="8%"> Block </th>
                           <th width="15%"> From </th>
                           <th width="15%"> To </th>
-                          <th width="10%"> ETC </th>
+                          <th width="10%"> {{ settings.symbol }} </th>
                           <th width="0%"> gas </th>
                           <th width="12%"> Age </th>
                       </tr>
@@ -85,7 +85,7 @@
                         <th width="8%"> Block </th>
                         <th width="15%"> From </th>
                         <th width="15%"> To </th>
-                        <th width="10%"> ETC </th>
+                        <th width="10%"> {{ settings.symbol }} </th>
                         <th width="0%"> gas </th>
                         <th></th>
                     </tr>

--- a/public/views/home.html
+++ b/public/views/home.html
@@ -75,7 +75,7 @@
                     <div class="todo-tasklist-controls"> 
                       <span class="todo-tasklist-item-text">From <a href="/addr/{{t.from}}">{{t.from.substr(0,24)}}...</a></span> 
                       <span class="todo-tasklist-item-text">To <a href="/addr/{{t.to}}">{{t.to.substr(0,24)}}...</a></span><br>
-                      <div class="todo-tasklist-item-text" style="margin-top:4px;">{{t.value}} Ether</div>
+                      <div class="todo-tasklist-item-text" style="margin-top:4px;">{{t.value}} {{settings.symbol}}</div>
                     </div>
                 </div>
 

--- a/public/views/token.html
+++ b/public/views/token.html
@@ -8,7 +8,7 @@
                 <span class="eth-stat-title">
                   {{ token.balance | number: 10 }} </span><br>
                 <span class="eth-stat-text">
-                  {{ token.name }} Address Balance (ETC)
+                  {{ token.name }} Address Balance ({{ settings.symbol }})
                   </span><br> 
                   <div class="margin-top-20">
                   {{ token.total_supply | number:1 }} <span class="eth-stat-text">Total {{ token.symbol }} Tokens</span>
@@ -102,7 +102,7 @@
                           <th width="8%"> Block </th>
                           <th width="15%"> From </th>
                           <th width="15%"> To </th>
-                          <th width="10%"> ETC </th>
+                          <th width="10%"> {{ settings.symbol }} </th>
                           <th width="0%"> gas </th>
                           <th width="12%"> Age </th>
                       </tr>

--- a/public/views/tx.html
+++ b/public/views/tx.html
@@ -18,7 +18,7 @@
                 <td><a href="/addr/{{tx.to}}">{{tx.to}}</a></td></tr>
           <tr ng-show="tx.creates"><td width="25%">creates</td>
                 <td><a href="/addr/{{tx.creates}}">{{tx.creates}}</a></td></tr>                
-          <tr ><td width="25%">value</td><td>{{tx.value}} ETC</td></tr>
+          <tr ><td width="25%">value</td><td>{{tx.value}} {{ settings.symbol }}</td></tr>
           <tr ><td width="25%">gas Provided</td><td>{{tx.gas}}</td></tr>
           <tr ><td width="25%">gasPrice</td><td>{{tx.gasPrice}}</td></tr>
           <tr ><td width="25%">nonce</td><td>{{tx.nonce}}</td></tr>

--- a/tools/config.json
+++ b/tools/config.json
@@ -3,5 +3,11 @@
     "blocks": [ {"start": 2000000, "end": "latest"}],
     "quiet": false,
     "terminateAtExistingDB": false,
-    "listenOnly": true
+    "listenOnly": true,
+    "settings": {
+        "symbol": "ETC",
+        "name": "Ethereum Classic",
+        "title": "Ethereum Classic Block Explorer",
+        "author": "Elaine"
+    }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,12 +6,12 @@
     <!--<![endif]-->
     <!-- BEGIN HEAD -->
     <head>
-        <title data-ng-bind="'Ethereum Classic | ' + $state.current.data.pageTitle"></title>
+        <title data-ng-bind="'<%= settings.name %> | ' + $state.current.data.pageTitle"></title>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta content="width=device-width, initial-scale=1" name="viewport" />
-        <meta content="Ethereum Classic Block Explorer" name="description"/>
-        <meta content="Elaine" name="author" />
+        <meta content="<%= settings.title %>" name="description"/>
+        <meta content="<%= settings.author %>" name="author" />
         <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico"/>
 
         <base href="/">


### PR DESCRIPTION
This is very simple fix to make the  ETC explorer more generic.
Site `settings` are lazy loaded by angular factory method.

for example. (site specific `config.json`)
~~~ json
{
    "gethPort": 9545,
    "blocks": [ {"start": 0, "end": "latest"}],
    "quiet": false,
    "terminateAtExistingDB": false,
    "listenOnly": true,
    "settings": {
        "symbol": "ESN",
        "name": "EtherSocial",
        "title": "EtherSocial Network Block Explorer",
        "author": "contact@blahblahblah"
    }
~~~
`settings` are served by `/config` url and loaded later.

further works are already done to customize header/footer/logo etc. (not committed yet publicly)