### PR TITLE
Remove 'All' option for transaction display on address pages

### DIFF
--- a/public/js/controllers/AddressController.js
+++ b/public/js/controllers/AddressController.js
@@ -71,8 +71,8 @@ angular.module('BlocksApp').controller('AddressController', function($stateParam
           });
         },
         "lengthMenu": [
-                    [10, 20, 50, 100, 150, -1],
-                    [10, 20, 50, 100, 150, "All"] // change per page values here
+                    [10, 20, 50, 100, 150, 500],
+                    [10, 20, 50, 100, 150, 500] // change per page values here
                 ],
         "pageLength": 20, 
         "order": [


### PR DESCRIPTION
This option is currently broken. Replacing it with 500 should be a good enough temporary fix.