### PR TITLE
WIP: Stats txns supply

### DIFF
--- a/db.js
+++ b/db.js
@@ -113,6 +113,7 @@ const Market = new Schema(
 );
 
 // create indices
+Transaction.index({timestamp:-1});
 Transaction.index({ blockNumber: -1 });
 Transaction.index({ from: 1, blockNumber: -1 });
 Transaction.index({ to: 1, blockNumber: -1 });

--- a/db.js
+++ b/db.js
@@ -112,6 +112,12 @@ const Market = new Schema(
   }, { collection: 'Market' },
 );
 
+const TxStat = new Schema(
+{
+    "timestamp": {type: Number, index: {unique: true}},
+    "txns": Number
+}, {collection: "TxStat"});
+
 // create indices
 Transaction.index({timestamp:-1});
 Transaction.index({ blockNumber: -1 });
@@ -131,6 +137,7 @@ TokenTransfer.index({ to: 1, blockNumber: -1 });
 TokenTransfer.index({ contract: 1, blockNumber: -1 });
 
 mongoose.model('BlockStat', BlockStat);
+mongoose.model('TxStat', TxStat);
 mongoose.model('Block', Block);
 mongoose.model('Account', Account);
 mongoose.model('Contract', Contract);
@@ -138,6 +145,7 @@ mongoose.model('Transaction', Transaction);
 mongoose.model('Market', Market);
 mongoose.model('TokenTransfer', TokenTransfer);
 module.exports.BlockStat = mongoose.model('BlockStat');
+module.exports.TxStat = mongoose.model('TxStat');
 module.exports.Block = mongoose.model('Block');
 module.exports.Contract = mongoose.model('Contract');
 module.exports.Transaction = mongoose.model('Transaction');

--- a/public/js/controllers/StatsController.js
+++ b/public/js/controllers/StatsController.js
@@ -21,6 +21,9 @@ angular.module('BlocksApp').controller('StatsController', function($stateParams,
         },
         "miner_hashrate": {
             "title": "Miner distribution"
+        },
+        "tx": {
+            "title": "Transaction chart"
         }
     }
 
@@ -884,6 +887,190 @@ angular.module('BlocksApp').controller('StatsController', function($stateParams,
                 tip.style("top", d3.event.pageY + 25 + "px");
 
                 focus.attr("transform", "translate(" + x(moment(x0).unix()*1000) + "," + y(s1.blockTime) + ")");
+            }
+
+            callback(null, 'three');
+        }
+        function myLastFunction(arg1, callback) {
+            // arg1 now equals 'three'
+            callback(null, 'done');
+        }
+      }
+    }
+  }
+})
+.directive('transactionChart', function($http) {
+  return {
+    restrict: 'E',
+    template: '<svg id="transaction" width="100%" height="500px"></svg>',
+    scope: true,
+    link: function(scope, elem, attrs) {
+      $http.post("/stats", {"action": "txns"})
+        .then(function(res) {
+
+          scope.init(res.data, "#transaction");
+        });
+
+      /**
+       * Created by chenxiangyu on 2016/8/5
+       * slightly modified for transaction.
+       */
+      scope.init = function(dataset, chartid) {
+        async.waterfall([
+            myFirstFunction,
+            mySecondFunction,
+            myLastFunction
+        ], function (err, result) {
+            // result now equals 'done'
+            return result;
+        });
+
+        function myFirstFunction(callback) {
+            callback(null, dataset, 'two');
+        }
+
+        function mySecondFunction(arg1, arg2, callback) {
+            var width1 = parseInt(d3.select(chartid).style("width"));
+
+            var margin = {top: 0, right: 10, bottom: 50, left: 65},
+                //var margin = {top: 30, right: 0, bottom: 0, left: 0},
+                // For Responsive web design, get window.innerWidth
+                //width = window.innerWidth - margin.left - margin.right,
+                width = width1 - margin.left - margin.right,
+                //width = window.screen.availWidth - margin.left - margin.right,
+                height = 400 - margin.top - margin.bottom;
+
+            // FIXME
+            if (width < 0) {
+                width = 1000;
+            }
+
+            var x = d3.time.scale().range([0, width]);
+            var y = d3.scale.linear().range([height, 0]);
+
+            // For Responsive web design
+            var tick = window.innerWidth < 800 ? 2:5;
+
+            var xAxis = d3.svg.axis()
+                .scale(x)
+                .orient("bottom")
+                .tickFormat(d3.time.format("%x"))
+                .ticks(tick);
+
+            var yAxis = d3.svg.axis()
+                .scale(y)
+                .orient("left")
+                .tickFormat(d3.format("s"))
+                .tickFormat(function(d){return d3.format("s")(d) + ' txns';})
+                .ticks(5);
+
+            var area = d3.svg.area()
+                .x(function(d) { return x(d.timestamp*1000); })
+                .y0(height)
+                .y1(function(d) { return y(d.txns); });
+
+            var valueline = d3.svg.line()
+                .x(function(d) { return x(d.timestamp*1000); })
+                .y(function(d) { return y(d.txns); });
+
+            var svg = d3.select(chartid)
+                .attr("width", width + margin.left + margin.right)
+                .attr("height", height + margin.top + margin.bottom)
+                .append("g")
+                .attr("transform",
+                    "translate(" + margin.left + "," + margin.top + ")");
+
+            // fix for mobile layout
+            var tick = window.innerWidth < 800 ? 15:30;
+
+            // function for the x grid lines
+            function make_x_axis() {
+                return d3.svg.axis()
+                    .scale(x)
+                    .orient("bottom")
+                    .ticks(tick)
+            }
+
+            // function for the y grid lines
+            function make_y_axis() {
+                return d3.svg.axis()
+                    .scale(y)
+                    .orient("left")
+                    .ticks(8)
+            }
+
+            var data = arg1;
+
+            // Scale the range of the data
+            x.domain(d3.extent(data, function(d) { return d.timestamp*1000; }));
+            y.domain([d3.min(data, function(d) { return d.txns; }), d3.max(data, function(d) { return d.txns; })]);
+
+            // Add the filled area
+            svg.append("path")
+                .datum(data)
+                .attr("class", "area")
+                .attr("d", area);
+
+            // Draw the x Grid lines
+            svg.append("g")
+                .attr("class", "grid")
+                .attr("transform", "translate(0," + height + ")")
+                .call(make_x_axis()
+                    .tickSize(-height, 0, 0)
+                    .tickFormat("")
+                );
+
+            // Draw the y Grid lines
+            svg.append("g")
+                .attr("class", "grid")
+                .call(make_y_axis()
+                    .tickSize(-width, 0, 0)
+                    .tickFormat("")
+                );
+
+            // Add the valueline path.
+            svg.append("path")
+                .attr("d", valueline(data));
+
+            // Add the X Axis
+            svg.append("g")
+                .attr("class", "x axis")
+                .attr("transform", "translate(0," + height + ")")
+                .call(xAxis);
+
+            // Add the Y Axis
+            svg.append("g")
+                .attr("class", "y axis")
+                .call(yAxis);
+
+            // Add Tooltip
+            var focus = svg.append("g")
+                .attr("class", "focus")
+                .style("display", "none");
+
+            focus.append("circle")
+                .attr("r", 4.5);
+
+            focus.append("text")
+                .attr("x", 9)
+                .attr("dy", ".35em");
+
+            svg.append("rect")
+                .attr("class", "overlay")
+                .attr("width", width)
+                .attr("height", height)
+                .on("mouseover", function() { focus.style("display", null); })
+                .on("mouseout", function() { focus.style("display", "none"); })
+                .on("mousemove", mousemove);
+
+            function mousemove() {
+                var x0 = x.invert(d3.mouse(this)[0]);
+
+                var s1 = _.minBy(data, function(d) {
+                    return Math.abs(moment(x0).unix()-d.timestamp);
+                });
+
+                focus.attr("transform", "translate(" + x(moment(x0).unix()*1000) + "," + y(s1.txns) + ")");
             }
 
             callback(null, 'three');

--- a/public/js/controllers/StatsController.js
+++ b/public/js/controllers/StatsController.js
@@ -256,7 +256,7 @@ angular.module('BlocksApp').controller('StatsController', function($stateParams,
                   dataset.push(d);
                 }
               });
-            } else if (k !== 'height') {
+            } else if (k !== 'height' && k != 'circulatingSupply') {
               var d = { _id: k, amount: res.data[k] };
               dataset.push(d);
             }

--- a/public/js/controllers/StatsController.js
+++ b/public/js/controllers/StatsController.js
@@ -1256,6 +1256,18 @@ angular.module('BlocksApp').controller('StatsController', function($stateParams,
                 .attr("class", "y axis")
                 .call(yAxis);
 
+            var tip = d3.tip()
+                .attr('class', 'd3-tip')
+                .offset([-10, 0])
+                .direction('s')
+                .html(function(d) {
+                    return '<div class="tooltip-arrow"></div>' +
+                        '<div class="tooltip-inner"><div class="small"><b>' +
+                        'Transactions: <b>' + d.txns + ' txns </b><br />' +
+                        '<b>' + d3.time.format("%x %H:%M")(new Date(d.timestamp * 1000)) + '</b>' +
+                        '</div></div>';
+                });
+
             // Add Tooltip
             var focus = svg.append("g")
                 .attr("class", "focus")
@@ -1268,12 +1280,23 @@ angular.module('BlocksApp').controller('StatsController', function($stateParams,
                 .attr("x", 9)
                 .attr("dy", ".35em");
 
+            svg.call(tip);
+
             svg.append("rect")
                 .attr("class", "overlay")
                 .attr("width", width)
                 .attr("height", height)
-                .on("mouseover", function() { focus.style("display", null); })
-                .on("mouseout", function() { focus.style("display", "none"); })
+                .on("mouseover", function() {
+                    var x0 = x.invert(d3.mouse(this)[0]);
+                    var s1 = _.minBy(data, function(d) {
+                        return Math.abs(moment(x0).unix()-d.timestamp);
+                    });
+                    tip.show(s1, this);
+                    tip.style("left", d3.event.pageX + 10 + "px");
+                    tip.style("top", d3.event.pageY + 25 + "px");
+                    focus.style("display", null);
+                 })
+                .on("mouseout", function() { tip.hide(); focus.style("display", "none"); })
                 .on("mousemove", mousemove);
 
             function mousemove() {
@@ -1282,6 +1305,10 @@ angular.module('BlocksApp').controller('StatsController', function($stateParams,
                 var s1 = _.minBy(data, function(d) {
                     return Math.abs(moment(x0).unix()-d.timestamp);
                 });
+
+                tip.show(s1, this);
+                tip.style("left", d3.event.pageX + 10 + "px");
+                tip.style("top", d3.event.pageY + 25 + "px");
 
                 focus.attr("transform", "translate(" + x(moment(x0).unix()*1000) + "," + y(s1.txns) + ")");
             }

--- a/public/tpl/header.html
+++ b/public/tpl/header.html
@@ -73,6 +73,10 @@
                         <a href="/stats/blocktime">
                         <i class="fa fa-line-chart"></i> Blocktime Chart</a>
                       </li>
+                      <li>
+                        <a href="/stats/tx">
+                        <i class="fa fa-line-chart"></i> Transaction Chart</a>
+                      </li>
                     </ul>
                   </div>
                 </div>

--- a/public/tpl/header.html
+++ b/public/tpl/header.html
@@ -77,6 +77,10 @@
                         <a href="/stats/tx">
                         <i class="fa fa-line-chart"></i> Transaction Chart</a>
                       </li>
+                      <li>
+                        <a href="/stats/supply">
+                        <i class="fa fa-line-chart"></i> Total Supply</a>
+                      </li>
                     </ul>
                   </div>
                 </div>

--- a/public/views/stats/index.html
+++ b/public/views/stats/index.html
@@ -8,6 +8,7 @@
         <blocktime-chart ng-if="chart == 'blocktime'"></blocktime-chart>
         <difficulty-chart ng-if="chart == 'difficulty'"></difficulty-chart>
         <transaction-chart ng-if="chart == 'tx'"></transaction-chart>
+        <total-supply ng-if="chart == 'supply'"></total-supply>
       </div>
     </div>
   </div>

--- a/public/views/stats/index.html
+++ b/public/views/stats/index.html
@@ -7,6 +7,7 @@
         <network-hashrate ng-if="chart == 'hashrate'"></network-hashrate>
         <blocktime-chart ng-if="chart == 'blocktime'"></blocktime-chart>
         <difficulty-chart ng-if="chart == 'difficulty'"></difficulty-chart>
+        <transaction-chart ng-if="chart == 'tx'"></transaction-chart>
       </div>
     </div>
   </div>

--- a/routes/index.js
+++ b/routes/index.js
@@ -144,7 +144,7 @@ var getBlock = function (req, res) {
  */
 var getTotalSupply = function(req, res) {
   var act;
-  if (req.params.act && ['total', 'totalSupply', 'genesisAlloc', 'minerRewards', 'uncleRewards'].indexOf(req.params.act) > -1) {
+  if (req.params.act && ['total', 'totalSupply', 'circulatingSupply', 'genesisAlloc', 'minerRewards', 'uncleRewards'].indexOf(req.params.act) > -1) {
     act = req.params.act;
     if (act === 'total') {
       act = 'totalSupply';
@@ -234,7 +234,9 @@ var getTotalSupply = function(req, res) {
       }
 
       var totalSupply = total.plus(genesisAlloc);
-      var ret = { "height": blockNumber, "totalSupply": totalSupply.div(1e+18), "genesisAlloc": genesisAlloc.div(1e+18), "minerRewards": total.div(1e+18) };
+      // circulationSupply = totalSupply - longterm reserve
+      var circulatingSupply = totalSupply.minus(rewards.longtermReserve || 0);
+      var ret = { "height": blockNumber, "circulatingSupply": circulatingSupply.div(1e+18), "totalSupply": totalSupply.div(1e+18), "genesisAlloc": genesisAlloc.div(1e+18), "minerRewards": total.div(1e+18) };
       if (req.method === 'POST' && typeof rewards.genesisAlloc === 'object') {
         ret.genesisAlloc = rewards.genesisAlloc;
       }
@@ -263,6 +265,7 @@ var getTotalSupply = function(req, res) {
               });
               ret.uncleRewards = totalUncleRewards.div(1e+18);
               ret.totalSupply = totalSupply.plus(totalUncleRewards).div(1e+18);
+              ret.circulatingSupply = circulatingSupply.plus(totalUncleRewards).div(1e+18);
               if (req.method === 'GET' && act) {
                 res.write(ret[act].toString());
               } else {
@@ -286,6 +289,7 @@ var getTotalSupply = function(req, res) {
         });
         ret.uncleRewards = totalUncleRewards.div(1e+18);
         ret.totalSupply = totalSupply.plus(totalUncleRewards).div(1e+18);
+        ret.circulatingSupply = circulatingSupply.plus(totalUncleRewards).div(1e+18);
       }
       if (req.method === 'GET' && act) {
         res.write(ret[act].toString());

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,8 +3,23 @@ const mongoose = require('mongoose');
 const Block = mongoose.model('Block');
 const Transaction = mongoose.model('Transaction');
 const Account = mongoose.model('Account');
+const _ = require('lodash');
 const async = require('async');
+const BigNumber = require('bignumber.js');
 const filters = require('./filters');
+
+var config = {};
+try {
+  config = require('../config.json');
+} catch(e) {
+  if (e.code == 'MODULE_NOT_FOUND') {
+    console.log('No config file found. Using default configuration... (config.example.json)');
+    config = require('../config.example.json');
+  } else {
+    throw e;
+    process.exit(1);
+  }
+}
 
 module.exports = function (app) {
   const web3relay = require('./web3relay');
@@ -34,6 +49,9 @@ module.exports = function (app) {
   app.post('/compile', compile);
 
   app.post('/stats', stats);
+  app.post('/supply', getTotalSupply);
+  app.get('/supply/:act', getTotalSupply);
+  app.get('/supply', getTotalSupply);
 };
 
 const getAddr = async (req, res) => {
@@ -119,10 +137,170 @@ var getBlock = function (req, res) {
     res.end();
   });
 };
-var getTx = function (req, res) {
-  const tx = req.body.tx.toLowerCase();
-  const txFind = Block.findOne({ 'transactions.hash': tx }, 'transactions timestamp')
-    .lean(true);
+
+/** 
+ * calc totalSupply
+ * total supply = genesis alloc + miner rewards + estimated uncle rewards
+ */
+var getTotalSupply = function(req, res) {
+  var act;
+  if (req.params.act && ['total', 'totalSupply', 'genesisAlloc', 'minerRewards', 'uncleRewards'].indexOf(req.params.act) > -1) {
+    act = req.params.act;
+    if (act === 'total') {
+      act = 'totalSupply';
+    }
+  }
+
+  Block.findOne({}).lean(true).sort('-number').exec(function (err, latest) {
+    if(err || !latest) {
+      console.error("getTotalSupply error: " + err)
+      res.write(JSON.stringify({"error": true}));
+      res.end();
+    } else {
+      console.log("getTotalSupply: latest block: " + latest.number);
+      var blockNumber = latest.number;
+
+      var total = new BigNumber(0);
+      var genesisAlloc = new BigNumber(0);
+      var blocks = [];
+
+      var rewards = {
+        enableECIP1017: true,
+        estimateUncle: 0.054, /* true: aggregate db // number(fractioal value): uncle rate // false: disable */
+        genesisAlloc: 72009990.50,
+        blocks: [
+          /* will be regeneragted later for ECIP1017 enabled case */
+          { start:        1, reward: 5e+18, uncle: 0.90625 },
+          { start:  5000001, reward: 4e+18, uncle:  0.0625 },
+          { start: 10000001, reward: 4e+18, uncle:  0.0625 },
+        ]
+      };
+
+      if (config.rewards) {
+        _.extend(rewards, config.rewards);
+      }
+
+      if (rewards && rewards.blocks) {
+        // get genesis alloc
+        if (typeof rewards.genesisAlloc === "object") {
+          genesisAlloc = new BigNumber(rewards.genesisAlloc.total) || new BigNumber(0);
+        } else {
+          genesisAlloc = new BigNumber(rewards.genesisAlloc) || new BigNumber(0);
+        }
+        genesisAlloc = genesisAlloc.times(new BigNumber(1e+18));
+
+        if (rewards.enableECIP1017) {
+          // regenerate reward block config for ETC
+          // https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1017.md
+          var reward = new BigNumber(5e+18);
+          var uncleRate = new BigNumber(1).div(32).plus(new BigNumber(7).div(8)); // 1/32(block miner) + 7/8(uncle miner)
+          blocks.push({start: 1, end: 5000000, reward, uncle: uncleRate});
+
+          reward = reward.times(0.8); // reduce 20%
+          uncleRate = new BigNumber(1).div(32).times(2); // 1/32(block miner) + 1/32(uncle miner)
+          blocks.push({start: 5000001, end: 10000000, reward, uncle: uncleRate});
+          currentBlock = 10000001;
+          var i = 2;
+          var lastBlock = blockNumber;
+          for (; lastBlock > currentBlock; currentBlock += 5000000) {
+            var start = blocks[i - 1].end + 1;
+            var end = start + 5000000 - 1;
+            reward = reward.times(0.8); // reduce 20%
+            blocks.push({start, end, reward, uncle: blocks[i - 1].uncle});
+            i++;
+          }
+          rewards.blocks = blocks;
+          blocks = [];
+        }
+
+        // check reward blocks, calc total miner's reward
+        rewards.blocks.forEach(function(block, i) {
+          if (blockNumber > block.start) {
+            var startBlock = block.start;
+            if (startBlock < 0) {
+              startBlock = 0;
+            }
+            var endBlock = blockNumber;
+            var reward = new BigNumber(block.reward);
+            if (rewards.blocks[i + 1] && blockNumber > rewards.blocks[i + 1].start) {
+              endBlock = rewards.blocks[i + 1].start - 1;
+            }
+            blocks.push({start: startBlock, end: endBlock, reward: reward, uncle: block.uncle });
+
+            var blockNum = endBlock - startBlock;
+            total = total.plus(reward.times(new BigNumber(blockNum)));
+          }
+        });
+      }
+
+      var totalSupply = total.plus(genesisAlloc);
+      var ret = { "height": blockNumber, "totalSupply": totalSupply.div(1e+18), "genesisAlloc": genesisAlloc.div(1e+18), "minerRewards": total.div(1e+18) };
+      if (req.method === 'POST' && typeof rewards.genesisAlloc === 'object') {
+        ret.genesisAlloc = rewards.genesisAlloc;
+      }
+
+      // estimate uncleRewards
+      var uncleRewards = [];
+      if (typeof rewards.estimateUncle === 'boolean' && rewards.estimateUncle && blocks.length > 0) {
+        // aggregate uncle blocks (slow)
+        blocks.forEach(function(block) {
+          Block.aggregate([
+            { $match: { number: { $gte: block.start, $lt: block.end } } },
+            { $group: { _id: null, uncles: { $sum: { $size: "$uncles" } } } }
+          ]).exec(function(err, results) {
+            if (err) {
+              console.log(err);
+            }
+            if (results && results[0] && results[0].uncles) {
+              // estimate Uncle Rewards
+              var reward = block.reward.times(new BigNumber(results[0].uncles)).times(block.uncle);
+              uncleRewards.push(reward);
+            }
+            if (uncleRewards.length === blocks.length) {
+              var totalUncleRewards = new BigNumber(0);
+              uncleRewards.forEach(function(reward) {
+                totalUncleRewards = totalUncleRewards.plus(reward);
+              });
+              ret.uncleRewards = totalUncleRewards.div(1e+18);
+              ret.totalSupply = totalSupply.plus(totalUncleRewards).div(1e+18);
+              if (req.method === 'GET' && act) {
+                res.write(ret[act].toString());
+              } else {
+                res.write(JSON.stringify(ret));
+              }
+              res.end();
+            }
+          });
+        });
+        return;
+      } else if (typeof rewards.estimateUncle === 'number' && rewards.estimateUncle > 0) {
+        // estimate Uncle rewards with uncle probability. (faster)
+        blocks.forEach(function(block) {
+          var blockcount = block.end - block.start;
+          var reward = block.reward.times(new BigNumber(blockcount).times(rewards.estimateUncle)).times(block.uncle);
+          uncleRewards.push(reward);
+        });
+        var totalUncleRewards = new BigNumber(0);
+        uncleRewards.forEach(function(reward) {
+          totalUncleRewards = totalUncleRewards.plus(reward);
+        });
+        ret.uncleRewards = totalUncleRewards.div(1e+18);
+        ret.totalSupply = totalSupply.plus(totalUncleRewards).div(1e+18);
+      }
+      if (req.method === 'GET' && act) {
+        res.write(ret[act].toString());
+      } else {
+        res.write(JSON.stringify(ret));
+      }
+      res.end();
+    }
+  });
+};
+
+var getTx = function(req, res){
+  var tx = req.body.tx.toLowerCase();
+  var txFind = Block.findOne( { "transactions.hash" : tx }, "transactions timestamp")
+                  .lean(true);
   txFind.exec((err, doc) => {
     if (!doc) {
       console.log(`missing: ${tx}`);


### PR DESCRIPTION
*Please do not merge it (WIP)*

any suggestions are welcomed

- [x] Transaction chart
  - [x] fix for speed issue => reduced range, make default range configurable.
- [x] total supply pie chart (`/stats/supply`) and normal total supply (`/supply`) for the coinmarketcap
  - [x] support ECIP1017 (enabled by default.)
  - [x] estimate uncle rewards correctly.

## simple URL APIs
- `/supply` : returns all info. as a json.
- `/supply/total` or `/supply/totalSupply` : the amount of total supply. (for coinmarketcap)
- `/supply/genesisAlloc` : genesis alloc
- `/supply/minerRewards` : the amount of all mined block rewards.
- `/supply/uncleRewards`: estimated uncle rewards.

## Screen shot
![image](https://user-images.githubusercontent.com/32324335/42436643-9a62e858-8395-11e8-9d1d-a398c01f1a05.png)


## References
- https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1017.md
- https://medium.com/@cseberino/calculating-ethereum-classic-mining-rewards-with-the-new-monetary-policy-9a1eccdfeb4c